### PR TITLE
Read pcap data from stdin ('-').

### DIFF
--- a/p0f.c
+++ b/p0f.c
@@ -468,7 +468,7 @@ static void prepare_pcap(void) {
     if (use_iface)
       FATAL("Options -i and -r are mutually exclusive.");
 
-    if (access((char*)read_file, R_OK))
+    if (access((char*)read_file, R_OK) && strcmp((char*)read_file, "-"))
       PFATAL("Can't access file '%s'.", read_file);
 
     pt = pcap_open_offline((char*)read_file, pcap_err);


### PR DESCRIPTION
Allow `p0f` to read pcap data from stdin.

While `pcap_open_offline` accepts `-` as a filename argument  indicating a synonym for stdin,  `p0f` checks the file using `access()` and fails with the following message:
```
cat ~/test.pcap | sudo ./p0f -r -
--- p0f 3.09b by Michal Zalewski <lcamtuf@coredump.cx> ---

[+] Closed 1 file descriptor.
[+] Loaded 322 signatures from 'p0f.fp'.
[-] SYSTEM ERROR : Can't access file '-'.
        Location : prepare_pcap(), p0f.c:472
      OS message : No such file or directory
```
The proposed change, also allows `-` as a filename, thus allowing `p0f` to read pcap data also from stdin.

Execution after the change:
```
cat ~/test.pcap | sudo ./p0f -r -
--- p0f 3.09b by Michal Zalewski <lcamtuf@coredump.cx> ---

[+] Closed 1 file descriptor.
[+] Loaded 322 signatures from 'p0f.fp'.
[+] Will read pcap data from file '-'.
[+] Default packet filtering configured [+VLAN].
[+] Processing capture data.


All done. Processed 207 packets.
```
